### PR TITLE
Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Upgrading
 Once you have installed vagga-box you can upgrade vagga inside the container
 using the following command-line::
 
-    vagga _box upgrade-vagga
+    vagga _box upgrade_vagga
 
 
 Short FAQ


### PR DESCRIPTION
 Command `vagga _box upgrade-vagga` raises `Unknown command 'upgrade-vagga'`
