### PR TITLE
Provide upgrade choices for stable and testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,11 @@ using the following command-line::
 
     vagga _box upgrade_vagga
 
+By default the command above will upgrade to the latest stable vagga version. If
+you want to upgrade to the latest testing version of vagga pass
+:code:`--testing` argument to the command::
+
+    vagga _box upgrade_vagga --testing
 
 Short FAQ
 =========

--- a/image/http/upgrade-vagga.sh
+++ b/image/http/upgrade-vagga.sh
@@ -1,2 +1,17 @@
 #!/bin/sh
-curl -sfS http://files.zerogw.com/vagga/vagga-install-testing.sh | sh
+
+case "$1" in
+    # If no arguments provided update to the latest stable version
+    ''|--stable)
+        install_script="vagga-install.sh"
+        ;;
+    --testing)
+        install_script="vagga-install-testing.sh"
+        ;;
+    *)
+        echo 'Specify one of "--stable", "--testing"' >&2
+        exit 1
+        ;;
+esac
+
+curl -sfS "http://files.zerogw.com/vagga/${install_script}" | sh

--- a/vagga_box/main.py
+++ b/vagga_box/main.py
@@ -110,8 +110,10 @@ def main():
             virtualbox.stop_vm()
             return sys.exit(0)
         elif args.command[1:2] == ['upgrade_vagga']:
+            upgrade_mode = args.command[2:3]
+            upgarde_cmd = ['/usr/local/bin/upgrade-vagga'] + upgrade_mode
             returncode = subprocess.Popen(
-                    BASE_SSH_COMMAND + ['/usr/local/bin/upgrade-vagga'],
+                    BASE_SSH_COMMAND + upgarde_cmd
                 ).wait()
             return sys.exit(returncode)
         elif args.command[1:2] == ['mount']:


### PR DESCRIPTION
It seems weird that by default stable version of vagga is installed in vagga-box but all updates are for testing version of vagga. The aim of this PR is to fix that and allow upgrades between stable versions of vagga in vagga_box.

This PR introduces the following changes:

- `upgrade_vagga` shell script can upgrade to either stable or testing version of vagga depending on command-line arguments passed
- `upgrade_vagga` by default upgrades vagga to the latest stable version. The motivation for this is that by definition testing version may contain unknown and unexpected bugs, which should not be present (by definition) in the stable version.
- `vagga _box upgrade_vagga` passes the first argument to the underlying shell script so the flags for `upgrade_vagga` can be used.

However still some **help and clarification are needed**. I have modified `upgrade-vagga.sh` but do not know how to rebuild image so my changes get into virtualbox. I suppose that some changes into code will also be required as the hash of the new image will be different from the hash of the current image.