### PR TITLE
Improve UX in upgrade_vagga command. Resolves #7

### DIFF
--- a/vagga_box/__init__.py
+++ b/vagga_box/__init__.py
@@ -9,3 +9,4 @@ BASE_SSH_COMMAND = [
     '-F', os.path.join(os.path.dirname(__file__), 'ssh_config'),
     'user@127.0.0.1',
 ]
+BASE_SSH_COMMAND_QUIET = BASE_SSH_COMMAND + ['-o LogLevel=QUIET']


### PR DESCRIPTION
Improve UX in upgrade_vagga command: print old vagga version and successful message with new version.

Before:
```sh
~ > vagga _box upgrade_vagga
Connection to 127.0.0.1 closed.
```

After:
```sh
~ > vagga _box upgrade_vagga
Starting upgrade vagga. Current version: v0.8.0-4-somevar
Connection to 127.0.0.1 closed.
Vagga successfully upgraded to v0.8.0-5-ge88d28b
All OK!
```

I'm not sure about `Connection to 127.0.0.1 closed.` phrase. It's prints to stderr, so if we want to  remove it, I think, we should parse for specified phrase... 